### PR TITLE
topページ以外へも直接リンクへ飛べるようにルーティング対応した

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
vercel上ではtopページのurlを直接踏むと404になっていた。
ローカルではこれは起こらなかった。
これはReact-routerでSPAにしていたのが問題らしい。

このコミットで修正した。

https://vercel.com/docs/rewrites